### PR TITLE
FIX: function type check bug; _writableState of process.stdout.write bug

### DIFF
--- a/ansi.js
+++ b/ansi.js
@@ -1,7 +1,7 @@
 /* internal variables */
 var csi = '\033[';
 var attributes = undefined;
-var output = process.stdout.write;
+var output = process.stdout.write.bind(process.stdout);
 var xy = {};
 
 /* ANSI colors */
@@ -124,7 +124,7 @@ module.exports.__defineGetter__("attributes",function() {
 	return attributes;
 });
 module.exports.__defineSetter__("output",function(func) {
-	if(typeof func == function)
+	if(typeof func == 'function')
 		output = func;
 	else if(func instanceof Array)
 		output = func.push;


### PR DESCRIPTION
When I run this lib, found it's not work in my code. changes this lines make it work now, according to SO:

http://stackoverflow.com/questions/28874665/node-js-cannot-read-property-defaultencoding-of-undefined
