### PR TITLE
gotoxy to accept an extra boolean parameter to gotoxy and cleartoeol

### DIFF
--- a/ansi.js
+++ b/ansi.js
@@ -36,8 +36,11 @@ var bg = {
 var normal = csi+'0m';
 
 /* functions */
-function gotoxy(x,y) {
+function gotoxy(x,y,clear) {
 	output(csi+y+';'+x+'H');
+  if (clear) {
+    cleartoeol();
+  }
 }
 function getxy() {
 	output(csi+'6n');

--- a/ansi.js
+++ b/ansi.js
@@ -38,9 +38,9 @@ var normal = csi+'0m';
 /* functions */
 function gotoxy(x,y,clear) {
 	output(csi+y+';'+x+'H');
-  if (clear) {
-    cleartoeol();
-  }
+	if (clear) {
+		cleartoeol();
+	}
 }
 function getxy() {
 	output(csi+'6n');

--- a/test/ansi-test.js
+++ b/test/ansi-test.js
@@ -4,6 +4,11 @@ var csi = require('../ansi');
 csi.attributes = csi.bg.green;
 csi.clear();
 
+/* should see 2 $$ sign only at x:40 y:15 */
+csi.gotoxy(40,15);
+csi.write("$$$$$$$");
+csi.gotoxy(42,15,true);
+
 /* move cursor to x:40, y:10 */
 csi.gotoxy(40,10);
 


### PR DESCRIPTION
I am using node-ansi. just found myself repeating gotoxy(x,y) then cleartoeol();
just thought it maybe nice to have gotoxy() take an extra boolean to gotoxy then cleartoeol